### PR TITLE
Rol/Permiso: Se creo la migracion de la tabla pivot permission/role

### DIFF
--- a/database/migrations/2025_08_14_172616_create_permission_role_table.php
+++ b/database/migrations/2025_08_14_172616_create_permission_role_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('permission_id');
+            
+            // Llaves foráneas comentadas temporalmente
+            // $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            // $table->foreign('permiso_id')->references('id')->on('permisos')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_role');
+    }
+};


### PR DESCRIPTION
- Se creó la migración para la tabla pivote `permission_role` que relaciona roles y permisos (relación muchos-a-muchos).
- No se crearon modelo ni controlador, ya que esta tabla pivote será manejada desde las relaciones belongsToMany en los modelos Role y Permission.
- Llaves foráneas (`role_id`, `permission_id`) quedaron comentadas temporalmente para evitar conflictos hasta que las tablas `roles` y `permissions` estén definitivas en develop.
- Pendiente: 
    1. Descomentar las FK en esta migración una vez migradas y seedadas las tablas `roles` y `permissions`.
    2. Crear el seeder para `permission_role` cuando existan todos los permisos en la base de datos."