### PR TITLE
feature/producto-servicio-impuesto: realización de la migración 

### DIFF
--- a/app/Http/Controllers/ProductServiceTaxController.php
+++ b/app/Http/Controllers/ProductServiceTaxController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ProductServiceTaxController extends Controller
+{
+    //
+}

--- a/app/Models/ProductServiceTax.php
+++ b/app/Models/ProductServiceTax.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ProductServiceTax extends Model
+{
+    //
+}

--- a/database/migrations/2025_08_15_005453_create_product_service_taxes_table.php
+++ b/database/migrations/2025_08_15_005453_create_product_service_taxes_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('product_service_taxes', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('Porcentaje', 5, 2);
+            $table->string('BaseImponible', 50);
+            $table->enum('TipoAplicacion', ['traslado', 'retenido']);
+
+            //$table->unsignedBigInteger('tax_id')->nullable(); // Llave foránea para la tabla de impuestos
+            //$table->unsignedBigInteger('product_service_id')->nullable(); // Llave foránea para la tabla de productos y servicios
+            
+            //$table->foreign('tax_id')->references('id')->on('taxes')->onDelete('cascade');
+            //$table->foreign('product_service_id')->references('id')->on('product_services')->onDelete('cascade');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('product_service_taxes');
+    }
+};


### PR DESCRIPTION
Se creó la migración para la tabla pivote product_service_tax que relaciona productos/servicios con impuestos (relación muchos a muchos).

No se crearon modelo ni controlador, ya que esta tabla pivote será manejada desde las relaciones belongsToMany en los modelos ProductService y Tax.

Las llaves foráneas (product_service_id y tax_id) quedaron comentadas temporalmente para evitar conflictos hasta que las tablas product_services y taxes estén definitivas.

Pendiente:

- Descomentar las llaves foráneas en esta migración una vez migradas y seedeadas las tablas product_services y taxes.

- Crear el seeder para product_service_tax cuando existan todos los productos, servicios e impuestos en la base de datos.