### PR TITLE
feature/unidad-medida: Completado migraion, modelo, controlador, fact…

### DIFF
--- a/app/Http/Controllers/MeasurementUnitController.php
+++ b/app/Http/Controllers/MeasurementUnitController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MeasurementUnit;
+use Illuminate\Http\Request;
+
+class MeasurementUnitController extends Controller
+{
+    // lista con filtros, relaciones y paginación
+    public function index()
+    {
+        $units = MeasurementUnit::included()->filter()->sort()->getOrPaginate();
+        return response()->json($units);
+    }
+
+    // crear una nueva unidad de medida
+    public function store(Request $request)
+    {
+        $request->validate([
+            'nombre'          => 'required|string|max:100',
+            'estado'          => 'required|in:Activo,Inactivo',
+            'codigo_dian'     => 'required|string|max:10|unique:measurement_units,codigo_dian',
+            'descripcion'     => 'nullable|string',
+            'tipo_aplicacion' => 'required|in:Producto,Servicio',
+        ]);
+
+        $unit = MeasurementUnit::create($request->all());
+        return response()->json($unit, 201);
+    }
+
+    // mostrar una unidad de medida por id
+    public function show($id)
+    {
+        $unit = MeasurementUnit::findOrFail($id);
+        return response()->json($unit);
+    }
+
+    // actualizar una unidad de medida
+    public function update(Request $request, MeasurementUnit $measurementUnit)
+    {
+        $request->validate([
+            'nombre'          => 'sometimes|string|max:100',
+            'estado'          => 'sometimes|in:Activo,Inactivo',
+            'codigo_dian'     => 'sometimes|string|max:10|unique:measurement_units,codigo_dian,' . $measurementUnit->id,
+            'descripcion'     => 'nullable|string',
+            'tipo_aplicacion' => 'sometimes|in:Producto,Servicio',
+        ]);
+
+        $measurementUnit->update($request->only(array_keys($request->all())));
+
+        return response()->json($measurementUnit);
+    }
+
+    // eliminar una unidad de medida
+    public function destroy(MeasurementUnit $measurementUnit)
+    {
+        $measurementUnit->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/MeasurementUnit.php
+++ b/app/Models/MeasurementUnit.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class MeasurementUnit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nombre',
+        'estado',
+        'codigo_dian',
+        'descripcion',
+        'tipo_aplicacion',
+    ];
+
+    // Las posibles relaciones que se pueden cargar vía query parameters en la API
+    protected $allowIncluded = ['products', 'services'];
+    // Campos por los que se puede filtrar la consulta
+    protected $allowFilter = ['id', 'nombre', 'estado', 'codigo_dian', 'tipo_aplicacion'];
+    // Campos por los que se puede ordenar la consulta
+    protected $allowSort = ['id', 'nombre', 'estado', 'codigo_dian'];
+
+
+    // Cardinalidad //
+
+    // Una unidad de medida puede tener muchos productos
+    public function products()
+    {
+        return $this->hasMany(Product::class, 'measurement_unit_id');
+    }
+    // Una unidad de medida puede tener muchos servicios
+    public function services()
+    {
+        return $this->hasMany(Service::class, 'measurement_unit_id');
+    }
+
+
+    // SCOPES PARA FILTROS, INCLUSIONES Y ORDENAMIENTO //
+
+    public function scopeIncluded(Builder $query)
+    {
+        if (empty($this->allowIncluded) || empty(request('included'))) {
+            return;
+        }
+        
+        $relations = explode(',', request('included'));
+        $allowIncluded = collect($this->allowIncluded);
+
+        foreach ($relations as $key => $relationship) {
+            if (!$allowIncluded->contains($relationship)) {
+                unset($relations[$key]);
+            }
+        }
+
+        $query->with($relations);
+    }
+
+    public function scopeFilter(Builder $query)
+    {
+        if (empty($this->allowFilter) || empty(request('filter'))) {
+            return;
+        }
+
+        $filters = request('filter');
+        $allowFilter = collect($this->allowFilter);
+
+        foreach ($filters as $filter => $value) {
+            if ($allowFilter->contains($filter)) {
+                $query->where($filter, 'LIKE', '%' . $value . '%');
+            }
+        }
+    }
+
+    public function scopeSort(Builder $query)
+    {
+        if (empty($this->allowSort) || empty(request('sort'))) {
+            return;
+        }
+
+        $sortFields = explode(',', request('sort'));
+        $allowSort = collect($this->allowSort);
+
+        foreach ($sortFields as $sortField) {
+            $direction = 'asc';
+
+            if (substr($sortField, 0, 1) == '-') {
+                $direction = 'desc';
+                $sortField = substr($sortField, 1);
+            }
+
+            if ($allowSort->contains($sortField)) {
+                $query->orderBy($sortField, $direction);
+            }
+        }
+    }
+
+    public function scopeGetOrPaginate(Builder $query)
+    {
+        if (request('perPage')) {
+            $perPage = intval(request('perPage'));
+            if ($perPage) {
+                return $query->paginate($perPage);
+            }
+        }
+
+        return $query->get();
+    }
+}
+

--- a/database/factories/MeasurementUnitFactory.php
+++ b/database/factories/MeasurementUnitFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\MeasurementUnit;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\MeasurementUnit>
+ */
+class MeasurementUnitFactory extends Factory
+{
+    protected $model = MeasurementUnit::class;
+
+    public function definition(): array
+    {
+        return [
+            'nombre' => $this->faker->unique()->word, // Nombre de la unidad
+            'estado' => $this->faker->randomElement(['Activo', 'Inactivo']),
+            'codigo_dian' => strtoupper($this->faker->unique()->bothify('??###')), // Código tipo DIAN
+            'descripcion' => $this->faker->sentence(6), // Descripción corta
+            'tipo_aplicacion' => $this->faker->randomElement(['Producto', 'Servicio']),
+        ];
+    }
+}
+

--- a/database/migrations/2025_08_22_013626_create_measurement_units_table.php
+++ b/database/migrations/2025_08_22_013626_create_measurement_units_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMeasurementUnitsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('measurement_units', function (Blueprint $table) {
+            $table->bigIncrements('id'); // PK
+            $table->string('nombre', 100);
+            $table->enum('estado', ['Activo', 'Inactivo'])->default('Activo');
+            $table->string('codigo_dian', 10)->unique(); // Código único de la DIAN
+            $table->text('descripcion')->nullable();
+            $table->enum('tipo_aplicacion', ['Producto', 'Servicio']);
+
+            $table->timestamps(); // created_at y updated_at
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('measurement_units');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,9 +15,11 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        // User::factory()->create([
+        //     'name' => 'Test User',
+        //     'email' => 'test@example.com',
+        // ]);
+
+        $this->call(MeasurementUnitTableSeeder::class);
     }
 }

--- a/database/seeders/MeasurementUnitTableSeeder.php
+++ b/database/seeders/MeasurementUnitTableSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\MeasurementUnit;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class MeasurementUnitTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Usa el factory para crear 50 registros
+        MeasurementUnit::factory()->count(50)->create();
+    }
+}


### PR DESCRIPTION
Se desarrolló el controlador MeasurementUnitController con todos los métodos necesarios para manejar la tabla measurement_units. Esto incluye index, store, show, update y destroy, permitiendo listar, crear, mostrar, actualizar y eliminar unidades de medida. Cada método cuenta con validaciones adecuadas y manejo de errores para asegurar que los datos enviados sean correctos, incluyendo la validación de campos únicos y tipos de dato válidos.

El modelo MeasurementUnit fue creado incluyendo los campos que permiten asignación masiva mediante $fillable. Se añadieron listas blancas con allowIncluded, allowFilter y allowSort para controlar qué relaciones se pueden cargar, qué campos se pueden filtrar y por cuáles se puede ordenar en las consultas de la API. Además, se definieron las relaciones con Product y Service (cardinalidad uno a muchos) y se implementaron scopes para filtros, inclusión de relaciones, ordenamiento y paginación, asegurando que la API sea flexible y eficiente.

La migración de measurement_units incluye todos los campos requeridos: id como BigInt autoincremental, nombre de tipo Varchar(100), estado como Enum con valores Activo o Inactivo, codigo_dian Varchar(10) único, descripcion de tipo Text y tipo_aplicacion como Enum con valores Producto o Servicio. Se definieron los tipos de dato y restricciones correspondientes, dejando la tabla lista para que las tablas hijas (products y services) puedan referenciarla mediante llave foránea.

Se desarrolló también el factory MeasurementUnitFactory para generar datos de prueba mediante Faker. Este factory permite crear registros con nombre único, estado aleatorio entre Activo e Inactivo, código DIAN generado de forma alfanumérica, descripción con frases aleatorias y tipo de aplicación aleatorio entre Producto y Servicio. Esto facilita la generación de datos realistas para pruebas automatizadas o para poblar la base de datos durante el desarrollo.

El seeder MeasurementUnitTableSeeder utiliza el factory para crear 50 registros de prueba, asegurando que la tabla cuente con suficiente información para probar la API y las relaciones con productos y servicios de manera efectiva. Esto permite validar los filtros, ordenamientos, relaciones y paginación directamente sobre datos consistentes.

Finalmente, las rutas para MeasurementUnit se definieron en api.php usando Route::apiResource('measurement-units', MeasurementUnitController::class), siguiendo el mismo estilo que las tablas payments y taxes. Esto genera automáticamente todas las rutas RESTful necesarias (index, store, show, update, destroy) y permite interactuar con la API de manera uniforme y consistente.

