### PR TITLE
Cambios en payment y RadianEvent

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -17,14 +17,14 @@ class PaymentController extends Controller
     // crear un nuevo pago
     public function store(Request $request)
     {
-        $request->validate([
-            'ElectronicInvoice_id' => 'required|exists:electronic_invoices,identificacion',
-            'PaymentMethod_id'     => 'required|exists:payment_methods,identificacion',
-            'fecha_pago'           => 'required|date',
-            'valor_pagado'         => 'required|numeric|min:0',
-            'moneda'               => 'required|string|max:3',
-            'referencia_pago'      => 'nullable|string|max:255',
-        ]);
+    $request->validate([
+        'electronic_invoice_id' => 'required|exists:electronic_invoices,id',
+        'payment_method_id'     => 'required|exists:payment_methods,id',
+        'fecha_pago'            => 'required|date',
+        'valor_pagado'          => 'required|numeric|min:0',
+        'moneda'                => 'required|string|max:3',
+        'referencia_pago'       => 'nullable|string|max:255',
+    ]);
 
         $payment = Payment::create($request->all());
         return response()->json($payment, 201);
@@ -41,8 +41,8 @@ class PaymentController extends Controller
     public function update(Request $request, Payment $payment)
     {
         $request->validate([
-            'ElectronicInvoice_id' => 'sometimes|exists:electronic_invoices,identificacion',
-            'PaymentMethod_id'     => 'sometimes|exists:payment_methods,identificacion',
+            'electronic_Invoice_id' => 'sometimes|exists:electronic_invoices,identificacion',
+            'payment_Method_id'     => 'sometimes|exists:payment_methods,identificacion',
             'fecha_pago'           => 'sometimes|date',
             'valor_pagado'         => 'sometimes|numeric|min:0',
             'moneda'               => 'sometimes|string|max:3',

--- a/app/Http/Controllers/RadianEventController.php
+++ b/app/Http/Controllers/RadianEventController.php
@@ -15,13 +15,14 @@ class RadianEventController extends Controller
 
     public function store(Request $request)
     {
-        $request->validate([
-            'codigo'                 => 'required|string|max:20',
-            'fecha_evento'           => 'required|date',
-            'tipo_evento'            => 'required|string|max:50',
-            'xml_respuesta'          => 'required|string',
-            'estado_dian'            => 'required|string|max:50',
-        ]);
+    $request->validate([
+        'electronic_document_id' => 'required|exists:electronic_documents,id',
+        'codigo'                 => 'required|string|max:20',
+        'fecha_evento'           => 'required|date',
+        'tipo_evento'            => 'required|string|max:50',
+        'xml_respuesta'          => 'required|string',
+        'estado_dian'            => 'required|string|max:50',
+    ]);
 
         $radian_event = RadianEvent::create($request->all());
         return response()->json($radian_event, 201);
@@ -33,7 +34,7 @@ class RadianEventController extends Controller
         return response()->json($radian_event);
     }
 
-    public function update(Request $request, RadianEvent $radian_event)
+    public function update(Request $request, RadianEvent $radianEvent)
     {
         $request->validate([
             'codigo'                 => 'sometimes|required|string|max:20',
@@ -43,9 +44,9 @@ class RadianEventController extends Controller
             'estado_dian'            => 'sometimes|required|string|max:50',
         ]);
 
-        $radian_event->update($request->only(array_keys($request->all())));
+        $radianEvent->update($request->only($radianEvent->getFillable()));
 
-        return response()->json($radian_event);
+        return response()->json($radianEvent);
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -13,9 +13,9 @@ class RoleController extends Controller
      */
     public function index()
     {
-        $role = Role::included()->filter()->sort()->getOrPaginate();
+        $roles = Role::included()->filter()->sort()->getOrPaginate();
 
-        return response()->json($role);
+        return response()->json($roles);
     }
 
     /**

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -31,32 +31,35 @@ class UserController extends Controller
      * Store a newly created resource in storage.
      */
     public function store(Request $request)
-    {
+{
+    $validated = $request->validate([
+        'company_id' => ['nullable', 'integer', 'exists:companies,id'],
+        'role_id' => ['nullable', 'integer'],
+        'nombre' => ['required', 'string', 'max:100'],
 
-        $validated = $request->validate([
-            'company_id' => ['nullable', 'integer', 'exists:companies,id'],
-            'role_id' => ['nullable', 'integer'], // Validar existencia cuando roles esté disponible
-            'nombre' => ['required', 'string', 'max:100'],
-            'tipo_documento' => ['nullable', 'string', 'max:20'],
-            'numero_documento' => ['required', 'string', 'max:50', 'unique:users,numero_documento'],
-            'direccion' => ['nullable', 'string', 'max:255'],
-            'pais' => ['nullable', 'string', 'max:100'],
-            'descripcion' => ['nullable', 'string'],
-            'correo_electronico' => ['required', 'email', 'max:150', 'unique:users,correo_electronico'],
-            'telefono' => ['nullable', 'string', 'max:20'],
-            'estado' => ['nullable', Rule::in(['Activo', 'Inactivo'])],
-            'ultimo_acceso' => ['nullable', 'date'],
-            'contrasena' => ['required', 'string', 'min:8'],
-        ]);
+        // 👇 validación que coincide con el enum
+        'tipo_documento' => ['nullable', Rule::in(['NIT', 'CC', 'CE'])],
+        'numero_documento' => ['required', 'string', 'max:50', 'unique:users,numero_documento'],
+        'direccion' => ['nullable', 'string', 'max:150'],
+        'pais' => ['nullable', 'string', 'max:100'],
+        'descripcion' => ['nullable', 'string', 'max:250'],
 
-        // se usa hash:make para guardar la contrasena encriptada
-        $user = User::create([
-            ...$validated,
-            'contrasena' => Hash::make($validated['contrasena']),
-        ]);
+        // 👇 corregido a 150
+        'correo_electronico' => ['required', 'email', 'max:150', 'unique:users,correo_electronico'],
+        'telefono' => ['nullable', 'string', 'max:20'],
+        'estado' => ['nullable', Rule::in(['Activo', 'Inactivo'])],
+        'ultimo_acceso' => ['nullable', 'date'],
+        'contrasena' => ['required', 'string', 'min:8'],
+    ]);
 
-        return response()->json($user);
-    }
+    $user = User::create([
+        ...$validated,
+        'contrasena' => Hash::make($validated['contrasena']),
+    ]);
+
+    return response()->json($user);
+}
+
 
     /**
      * Display the specified resource.

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -11,18 +11,18 @@ class Payment extends Model
     use HasFactory;
 
     // Campos que se pueden asignar masivamente
-    protected $fillable = [
-        'ElectronicInvoice_id',
-        'PaymentMethod_id',
+protected $fillable = [
+        'electronic_invoice_id',
+        'payment_method_id',
         'fecha_pago',
         'valor_pagado',
         'moneda',
         'referencia_pago',
-    ];
+];
 
 
     // Las posibles relaciones (includes) que se pueden cargar a través de query parameters en la API
-    protected $allowIncluded = ['electronicInvoice', 'paymentMethod'];
+    protected $allowIncluded = ['Electronic_Invoice', 'Payment_Method'];
     // Campos por los que se puede filtrar la consulta
     protected $allowFilter = ['fecha_pago', 'valor_pagado', 'moneda'];
     // Campos por los que se puede ordenar la consulta
@@ -33,12 +33,12 @@ class Payment extends Model
     // Muchos pagos pertenecen a una factura electrónica (muchos a uno)
     public function electronicInvoice()
     {
-        return $this->belongsTo(ElectronicInvoice::class, 'ElectronicInvoice_id', 'identificacion');
+        return $this->belongsTo(ElectronicInvoice::class, 'electronic_invoice_id');
     }
-    // Muchos pagos pertenecen a un método de pago (muchos a uno)
+
     public function paymentMethod()
     {
-        return $this->belongsTo(PaymentMethod::class, 'PaymentMethod_id');
+        return $this->belongsTo(PaymentMethod::class, 'payment_method_id');
     }
 
     // SCOPES //

--- a/app/Models/RadianEvent.php
+++ b/app/Models/RadianEvent.php
@@ -9,8 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 class RadianEvent extends Model
 {
     use HasFactory;
-    
+
     protected $fillable = [
+        'electronic_document_id',
         'codigo',
         'fecha_evento',
         'tipo_evento',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,14 +34,39 @@ class User extends Authenticatable
         'ultimo_acceso',
     ];
 
-    protected $AllowIncluded = [ 
-        'company',   // relación con la empresa
-        'role',    // relación con role
-    ];     
+    // 👇 todo en minúsculas
+    protected $allowIncluded = [
+        'company',
+        'role',
+    ];
 
-    protected $AllowFilter = [ 'company_id', 'nombre', 'tipo_documento', 'numero_documento', 'direccion', 'pais', 'descripcion', 'correo_electronico', 'telefono', 'estado', 'ultimo_acceso' ];
-    protected $AllowSort = [ 'company_id', 'nombre', 'tipo_documento', 'numero_documento', 'direccion', 'pais', 'descripcion', 'correo_electronico', 'telefono', 'estado', 'ultimo_acceso' ];
+    protected $allowFilter = [
+        'company_id',
+        'nombre',
+        'tipo_documento',
+        'numero_documento',
+        'direccion',
+        'pais',
+        'descripcion',
+        'correo_electronico',
+        'telefono',
+        'estado',
+        'ultimo_acceso'
+    ];
 
+    protected $allowSort = [
+        'company_id',
+        'nombre',
+        'tipo_documento',
+        'numero_documento',
+        'direccion',
+        'pais',
+        'descripcion',
+        'correo_electronico',
+        'telefono',
+        'estado',
+        'ultimo_acceso'
+    ];
     public function company()
     {
         return $this->belongsTo(Company::class);

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/sanctum": "^4.0",
+        "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85c1d2065f70e38b0d6bf66559fb13c5",
+    "content-hash": "9e8009f62639975c287d610dda66cb45",
     "packages": [
         {
             "name": "brick/math",

--- a/database/migrations/2025_08_22_015000_create_users_table.php
+++ b/database/migrations/2025_08_22_015000_create_users_table.php
@@ -12,31 +12,29 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+    $table->id();
 
-            // Clave foránea hacia companies
-            $table->unsignedBigInteger('company_id')->nullable();
-            //$table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
+    $table->unsignedBigInteger('company_id')->nullable();
+    $table->unsignedBigInteger('role_id')->nullable();
 
-            // Clave foránea hacia roles (tabla separada)
-            $table->unsignedBigInteger('role_id')->nullable();
-            // $table->foreign('role_id')->references('id')->on('roles')->onDelete('set null'); // Agregar cuando roles esté disponible
+    $table->string('nombre', 100);
 
-            $table->string('nombre', 100);
-            $table->enum('tipo_documento', ['NIT', 'CC', 'CE']);
-            $table->string('numero_documento', 15);
-            $table->string('direccion', 150);
-            $table->string('pais', 100);
-            $table->string('descripcion', 250);
-            $table->string('contrasena', 225);
-            $table->string('correo_electronico', 100)->unique();
-            $table->string('telefono', 20);
-            $table->enum('estado', ['Activo', 'Inactivo'])->default('Activo');
-            $table->timestamp('ultimo_acceso');
+    // 👇 ahora permite NULL
+    $table->enum('tipo_documento', ['NIT', 'CC', 'CE'])->nullable();
+    $table->string('numero_documento', 50)->unique();    // antes 15
+    $table->string('direccion', 150)->nullable();
+    $table->string('pais', 100)->nullable();
+    $table->string('descripcion', 250)->nullable();
+    $table->string('contrasena', 225);
+    $table->string('correo_electronico', 150)->unique(); // antes 100
+    $table->string('telefono', 20)->nullable();
+    $table->enum('estado', ['Activo', 'Inactivo'])->default('Activo');
+    $table->timestamp('ultimo_acceso')->nullable();      // antes NOT NULL
 
-            $table->rememberToken();
-            $table->timestamps();
-        });
+    $table->rememberToken();
+    $table->timestamps();
+});
+
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
             $table->string('email')->primary();

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,10 @@ use App\Http\Controllers\TaxController;
 use App\Http\Controllers\UserController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ServiceController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\InvoiceDetailController;
+use App\Http\Controllers\ProductTaxController;
 
 use App\Http\Controllers\OrmController;
 
@@ -26,10 +30,10 @@ Route::get('/user', function (Request $request) {
 Route::apiResource('companies',CompanyController::class);
 Route::apiResource('users', UserController::class);
 Route::apiResource('roles', RoleController::class);
-//Route::apiResource('products', ProductController::class);
-//Route::apiResource('services', ServiceController::class);
+Route::apiResource('products', ProductController::class);
+Route::apiResource('services', ServiceController::class);
 Route::apiResource('measurementUnints', MeasurementUnitController::class); // unidad-medida
-//Route::apiResource('invoiceDetails', ElectronicInvoiceController::class); // detalle-factura
+Route::apiResource('invoiceDetails', ElectronicInvoiceController::class); // detalle-factura
 Route::apiResource('payments', PaymentController::class);
 Route::apiResource('paymentMethods', PaymentMethodController::class); // metodo-pago
 Route::apiResource('creditDebitNotes', CreditDebitNoteController::class); // nota-credito-debito


### PR DESCRIPTION
Cambios realizados 

Método Post de Payment:

Se corrigió la incongruencia entre los nombres de las columnas de la base de datos y los atributos definidos en el modelo y en las validaciones del controlador.

En la migración, las columnas estaban definidas como electronic_invoice_id y payment_method_id.

En el modelo Payment y en el PaymentController se usaban ElectronicInvoice_id y PaymentMethod_id, lo cual provocaba un 500 Internal Server Error al intentar crear un pago porque los nombres no coincidían.

También se ajustaron las reglas de validación exists para que apunten a la columna correcta (id) en las tablas electronic_invoices y payment_methods.

Con estos cambios:

Se actualizaron los campos $fillable en el modelo Payment.

Se corrigieron las validaciones del método store en el controlador.

Se ajustaron las relaciones belongsTo en el modelo para usar las claves foráneas correctas.

Ahora el método POST /payments funciona correctamente y permite crear pagos sin errores.


Método post RadianEvent:

corregido error en creación (POST)

El método store fallaba con error 500 porque `electronic_document_id` 
es obligatorio en la BD, pero no se enviaba ni estaba en $fillable.  

✔ Se agregó `electronic_document_id` a $fillable.  
✔ Se actualizó la validación en el controlador.  
✔ Se ajustó el payload del POST para incluir el campo.  

Ahora los eventos se crean correctamente asociados a un documento electrónico.

y se arreglo el put de RadianEvent